### PR TITLE
chore(deps): CP-6366 additional updates for python and pipenv version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python3.12
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #  (e.g. ENV=production make setup).
 ENV ?= local
 # PYTHON specifies the python binary to use when creating virtualenv
-PYTHON ?= python3.9
+PYTHON ?= python3.12
 
 # Editor can be defined globally but defaults to nano
 EDITOR ?= nano

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,8 @@
 
 trigger:
   - main
+  - chore/*
+  - feature/*
 
 pool:
   vmImage: ubuntu-latest
@@ -27,7 +29,8 @@ jobs:
         parameters:
           coverage: app,core,status
           root_dir: ./
-          python_version: 3.9
+          python_version: 3.12
+          pipenv_version: 2023.12.1
   - job: build
     displayName: Build
     dependsOn: PythonTest


### PR DESCRIPTION
### For https://croudtech.atlassian.net/browse/CP-6366
---

- It appears there was mixed python versions referenced which i missed yesterday, 3.8/3.9.. all have been updated to 3.12 now
- Updates the pipenv version in the pipelines test stage
- Updates the triggers in the pipelines also
